### PR TITLE
Allow passwords with spaces

### DIFF
--- a/speakeasy.go
+++ b/speakeasy.go
@@ -1,6 +1,7 @@
 package speakeasy
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 )
@@ -16,7 +17,8 @@ func Ask(prompt string) (password string, err error) {
 }
 
 func readline() (value string, err error) {
-	_, err = fmt.Fscanln(os.Stdin, &value)
+	input := bufio.NewReader(os.Stdin)
+	value, err = input.ReadString('\n')
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Passwords with spaces currently cause an error:

```
> go run example/main.go  <I type a password with spaces>
Please enter a password: failed during password entry: expected newline
exit status 1
```

This commit uses a `bufio.NewReader` to read an entire line of user input.
