### PR TITLE
Stop listening for signals after password input

### DIFF
--- a/speakeasy_unix.go
+++ b/speakeasy_unix.go
@@ -47,6 +47,7 @@ func getPassword() (password string, err error) {
 	}
 
 	// Turn on the terminal echo and stop listening for signals.
+	defer signal.Stop(sig)
 	defer close(brk)
 	defer echoOn(fd)
 


### PR DESCRIPTION
The current code doesn't really stop listening for signals, it just makes the signal goroutine exit.
That's still good for memory leaks, but you also want to stop delivering signals to the channels
as well, otherwise they don't get their default behavior anymore.