### PR TITLE
Prevent Wait4 data race

### DIFF
--- a/speakeasy_unix.go
+++ b/speakeasy_unix.go
@@ -19,9 +19,8 @@ import (
 const sttyArg0 = "/bin/stty"
 
 var (
-	sttyArgvEOff []string           = []string{"stty", "-echo"}
-	sttyArgvEOn  []string           = []string{"stty", "echo"}
-	ws           syscall.WaitStatus = 0
+	sttyArgvEOff = []string{"stty", "-echo"}
+	sttyArgvEOn  = []string{"stty", "echo"}
 )
 
 // getPassword gets input hidden from the terminal from a user. This is
@@ -51,7 +50,7 @@ func getPassword() (password string, err error) {
 	defer close(brk)
 	defer echoOn(fd)
 
-	syscall.Wait4(pid, &ws, 0, nil)
+	syscall.Wait4(pid, nil, 0, nil)
 
 	line, err := readline()
 	if err == nil {
@@ -77,7 +76,7 @@ func echoOn(fd []uintptr) {
 	// Turn on the terminal echo.
 	pid, e := syscall.ForkExec(sttyArg0, sttyArgvEOn, &syscall.ProcAttr{Dir: "", Files: fd})
 	if e == nil {
-		syscall.Wait4(pid, &ws, 0, nil)
+		syscall.Wait4(pid, nil, 0, nil)
 	}
 }
 


### PR DESCRIPTION
`getPassword` and `echoOn` were concurrently writing to the same global `ws` variable, causing a data race. We don't actually care about the value of `ws` in this code, so we can simply pass a `nil` to `syscall.Wait4` instead.