### PR TITLE
Solaris support

### DIFF
--- a/speakeasy_unix.go
+++ b/speakeasy_unix.go
@@ -4,7 +4,7 @@
 // Original code is based on code by RogerV in the golang-nuts thread:
 // https://groups.google.com/group/golang-nuts/browse_thread/thread/40cc41e9d9fc9247
 
-// +build darwin freebsd linux netbsd openbsd
+// +build darwin freebsd linux netbsd openbsd solaris
 
 package speakeasy
 


### PR DESCRIPTION
I tested the fix on Illumos-based system. The supplied speakeasy_unix.go file works on solaris (tested with GO 1.5)