### PR TITLE
Add 'AskQuiet' to speakeasy

### DIFF
--- a/speakeasy.go
+++ b/speakeasy.go
@@ -14,16 +14,18 @@ func Ask(prompt string) (password string, err error) {
 	return FAsk(os.Stdout, prompt)
 }
 
-// Same as the Ask function, except it is possible to specify the file to write
-// the prompt to.
+// FAsk is the same as Ask, except it is possible to specify the file to write
+// the prompt to. If 'nil' is passed as the writer, no prompt will be written.
 func FAsk(wr io.Writer, prompt string) (password string, err error) {
-	if prompt != "" {
+	if wr != nil && prompt != "" {
 		fmt.Fprint(wr, prompt) // Display the prompt.
 	}
 	password, err = getPassword()
 
 	// Carriage return after the user input.
-	fmt.Fprintln(wr, "")
+	if wr != nil {
+		fmt.Fprintln(wr, "")
+	}
 	return
 }
 


### PR DESCRIPTION
AskQuiet will not prompt the user for a password, and will not print a carriage
return. The user must know to type the password, because there will not be a
prompt.

Was useful for me because I was sending output to stdout for piping to other processes, but still needed to ask for an encryption password.

Probably a narrow use case, but thought I'd PR anyway.